### PR TITLE
リーダーペンギンの経路表示機能を追加

### DIFF
--- a/src/components/LeaderPathDrawer.ts
+++ b/src/components/LeaderPathDrawer.ts
@@ -1,0 +1,140 @@
+/**
+ * リーダーペンギンの経路描画を担当するユーティリティクラス
+ */
+
+export interface PathPoint {
+  x: number;
+  z: number;
+  timestamp: number;
+}
+
+export interface LeaderPathColors {
+  [key: string]: string;
+}
+
+export class LeaderPathDrawer {
+  private ctx: CanvasRenderingContext2D;
+  private scaleX: (x: number) => number;
+  private scaleZ: (z: number) => number;
+  private pathColors: LeaderPathColors;
+
+  constructor(
+    ctx: CanvasRenderingContext2D, 
+    scaleX: (x: number) => number, 
+    scaleZ: (z: number) => number,
+    pathColors: LeaderPathColors = {
+      'Luca': '#9C27B0',  // 紫
+      'Miro': '#2196F3',  // 青
+      'Ellie': '#FF9800', // オレンジ
+      'Sora': '#4CAF50'   // 緑
+    }
+  ) {
+    this.ctx = ctx;
+    this.scaleX = scaleX;
+    this.scaleZ = scaleZ;
+    this.pathColors = pathColors;
+  }
+
+  /**
+   * リーダーペンギンの経路を描画する
+   * @param leaderPaths リーダー名をキーとした経路ポイントの配列
+   */
+  drawPaths(leaderPaths: Record<string, PathPoint[]>): void {
+    // 各リーダーの経路を描画
+    Object.entries(leaderPaths).forEach(([leaderName, path]) => {
+      this.drawSinglePath(leaderName, path);
+    });
+  }
+
+  /**
+   * 単一のリーダーペンギンの経路を描画する
+   * @param leaderName リーダーの名前
+   * @param path 経路ポイントの配列
+   */
+  private drawSinglePath(leaderName: string, path: PathPoint[]): void {
+    if (path.length < 2) return; // 少なくとも2点必要
+    
+    const color = this.pathColors[leaderName] || '#000000';
+    
+    this.ctx.beginPath();
+    this.ctx.strokeStyle = color;
+    this.ctx.lineWidth = 2;
+    this.ctx.setLineDash([]);
+    
+    // 最初のポイントに移動
+    const firstPoint = path[0];
+    this.ctx.moveTo(this.scaleX(firstPoint.x), this.scaleZ(firstPoint.z));
+    
+    // 残りのポイントを線で結ぶ
+    for (let i = 1; i < path.length; i++) {
+      const point = path[i];
+      this.ctx.lineTo(this.scaleX(point.x), this.scaleZ(point.z));
+    }
+    
+    this.ctx.stroke();
+    
+    // 経路の終点（最新の位置）に小さな円を描画
+    if (path.length > 0) {
+      const lastPoint = path[path.length - 1];
+      this.ctx.beginPath();
+      this.ctx.arc(this.scaleX(lastPoint.x), this.scaleZ(lastPoint.z), 3, 0, Math.PI * 2);
+      this.ctx.fillStyle = color;
+      this.ctx.fill();
+    }
+  }
+
+  /**
+   * 経路の最大長を制限する
+   * @param paths 現在の経路データ
+   * @param maxLength 最大長
+   * @returns 最大長に制限された経路データ
+   */
+  static limitPathsLength(
+    paths: Record<string, PathPoint[]>, 
+    maxLength: number
+  ): Record<string, PathPoint[]> {
+    const newPaths = { ...paths };
+    
+    Object.keys(newPaths).forEach(key => {
+      newPaths[key] = newPaths[key].slice(-maxLength);
+    });
+    
+    return newPaths;
+  }
+
+  /**
+   * 新しい位置ポイントを経路に追加する
+   * @param paths 現在の経路データ
+   * @param leaderName リーダー名
+   * @param x X座標
+   * @param z Z座標
+   * @param maxLength 経路の最大長
+   * @returns 更新された経路データ
+   */
+  static addPointToPath(
+    paths: Record<string, PathPoint[]>,
+    leaderName: string,
+    x: number,
+    z: number,
+    maxLength: number
+  ): Record<string, PathPoint[]> {
+    const newPaths = { ...paths };
+    const currentTime = Date.now();
+    
+    // 前回の位置と同じ場合は追加しない（経路が冗長になるのを防ぐ）
+    const prevPoints = paths[leaderName] || [];
+    const lastPoint = prevPoints.length > 0 ? prevPoints[prevPoints.length - 1] : null;
+    
+    if (!lastPoint || (lastPoint.x !== x || lastPoint.z !== z)) {
+      const newPoint: PathPoint = { x, z, timestamp: currentTime };
+      
+      // 新しい位置を追加し、最大長を超えたら古いポイントを削除
+      newPaths[leaderName] = [
+        ...(newPaths[leaderName] || []), 
+        newPoint
+      ].slice(-maxLength);
+    }
+    
+    return newPaths;
+  }
+}

--- a/src/components/LeaderPathDrawer.ts
+++ b/src/components/LeaderPathDrawer.ts
@@ -24,7 +24,7 @@ export class LeaderPathDrawer {
     scaleZ: (z: number) => number,
     pathColors: LeaderPathColors = {
       'Luca': '#9C27B0',  // 紫
-      'Miro': '#2196F3',  // 青
+      'Milo': '#2196F3',  // 青
       'Ellie': '#FF9800', // オレンジ
       'Sora': '#4CAF50'   // 緑
     }

--- a/src/components/PenguinMap.tsx
+++ b/src/components/PenguinMap.tsx
@@ -263,14 +263,14 @@ const PenguinMap = () => {
   // リーダーペンギンの経路を保存するための状態
   const [leaderPaths, setLeaderPaths] = useState<Record<string, PathPoint[]>>({
     'Luca': [],
-    'Miro': [],
+    'Milo': [],
     'Ellie': [],
     'Sora': []
   });
   
   // 経路表示の設定
   const [showPaths, setShowPaths] = useState<boolean>(true);
-  const [pathMaxLength, setPathMaxLength] = useState<number>(100); // 経路の最大ポイント数
+  const [pathMaxLength, setPathMaxLength] = useState<number>(250); // 経路の最大ポイント数
 
   // WebSocket接続の設定
   useEffect(() => {
@@ -292,7 +292,7 @@ const PenguinMap = () => {
             setPenguins(data.penguins);
             
             // リーダーペンギンの位置を記録
-            const leaderNames = ['Luca', 'Miro', 'Ellie', 'Sora'];
+            const leaderNames = ['Luca', 'Milo', 'Ellie', 'Sora'];
             
             // 各リーダーペンギンの位置を更新
             setLeaderPaths(prevPaths => {
@@ -473,7 +473,7 @@ const PenguinMap = () => {
       // リーダーごとの経路色
       const pathColors = {
         'Luca': '#9C27B0',  // 紫
-        'Miro': '#2196F3',  // 青
+        'Milo': '#2196F3',  // 青
         'Ellie': '#FF9800', // オレンジ
         'Sora': '#4CAF50'   // 緑
       };
@@ -484,7 +484,7 @@ const PenguinMap = () => {
     }
 
     // リーダーの名前リスト
-    const leaderNames = ['Luca', 'Miro', 'Ellie', 'Sora'];
+    const leaderNames = ['Luca', 'Milo', 'Ellie', 'Sora'];
 
     // ペンギンの状態に応じた色を取得する関数
     const getPenguinColor = (penguin: PenguinData): string => {
@@ -629,10 +629,9 @@ const PenguinMap = () => {
               value={pathMaxLength} 
               onChange={(e) => changePathMaxLength(Number(e.target.value))}
             >
-              <option value="50">50 ポイント</option>
-              <option value="100">100 ポイント</option>
-              <option value="200">200 ポイント</option>
+              <option value="250">250 ポイント</option>
               <option value="500">500 ポイント</option>
+              <option value="1000">1000 ポイント</option>
             </select>
           </div>
         </PathControls>
@@ -667,10 +666,10 @@ const PenguinMap = () => {
       <LegendContainer>
         <FollowersGraph>
           <h3>リーダーごとのフォロワー数</h3>
-          {['Luca', 'Miro', 'Ellie', 'Sora'].map(leaderName => {
+          {['Luca', 'Milo', 'Ellie', 'Sora'].map(leaderName => {
             const leader = penguins.find(p => p.name === leaderName);
             const followerCount = leader?.followerCount || 0;
-            const maxFollowers = Math.max(...penguins.filter(p => ['Luca', 'Miro', 'Ellie', 'Sora'].includes(p.name)).map(p => p.followerCount || 0));
+            const maxFollowers = Math.max(...penguins.filter(p => ['Luca', 'Milo', 'Ellie', 'Sora'].includes(p.name)).map(p => p.followerCount || 0));
             const percentage = maxFollowers > 0 ? (followerCount / maxFollowers) * 100 : 0;
 
             return (
@@ -729,7 +728,7 @@ const PenguinMap = () => {
           </div>
           <div className="legend-item">
             <div className="color-box" style={{ backgroundColor: '#2196F3' }} />
-            <span>Miro の経路</span>
+            <span>Milo の経路</span>
           </div>
           <div className="legend-item">
             <div className="color-box" style={{ backgroundColor: '#FF9800' }} />
@@ -742,7 +741,7 @@ const PenguinMap = () => {
         </div>
         
         <div className="legend-section">
-          <h3>リーダー状態 (Luca, Miro, Ellie, Sora)</h3>
+          <h3>リーダー状態 (Luca, Milo, Ellie, Sora)</h3>
           <div className="legend-item">
             <div className="color-box" style={{ backgroundColor: '#9C27B0' }} />
             <span>リーダー行動中 (Status: Leading)</span>


### PR DESCRIPTION
リーダーペンギン（Luca, Miro, Ellie, Sora）の移動経路を線で表示する機能を追加しました。

## 追加機能
- リーダーペンギンの移動経路を色分けして表示
- 経路表示のON/OFF切り替え機能
- 経路の最大長を設定する機能（50, 100, 200, 500ポイント）
- 各リーダーの経路色を凡例に追加

## 実装の工夫
- 経路描画機能を `LeaderPathDrawer` クラスに分離し、コードの可読性と再利用性を向上
- 同じ位置の重複登録を防止し、経路データを最適化
- リーダーごとに異なる色で経路を表示し、視認性を向上